### PR TITLE
More decoupling

### DIFF
--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -1,5 +1,10 @@
+output "resource_group_name" {
+  description = "Resource Group Name"
+  value       = azurerm_resource_group.platform.name
+}
+
 output "resource_group_url" {
-  description = "Resource Group"
+  description = "Resource Group URL"
   value       = "${local.portal_prefix}${azurerm_resource_group.platform.id}${local.portal_suffix}"
 }
 

--- a/terraform/azure/terraform.tf
+++ b/terraform/azure/terraform.tf
@@ -22,14 +22,14 @@ terraform {
     }
   }
 
-  //  # see https://www.terraform.io/docs/language/settings/backends/remote.html
-  //  backend "remote" {
-  //    hostname     = "app.terraform.io"
-  //    organization = "a-demo-organization"
-  //
-  //    # see https://www.terraform.io/docs/language/settings/backends/remote.html#workspaces
-  //    workspaces {
-  //      name = "dci-azure"
-  //    }
-  //  }
+  # see https://www.terraform.io/docs/language/settings/backends/remote.html
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "a-demo-organization"
+
+    # see https://www.terraform.io/docs/language/settings/backends/remote.html#workspaces
+    workspaces {
+      name = "dci-azure"
+    }
+  }
 }

--- a/terraform/consul/data_sources.tf
+++ b/terraform/consul/data_sources.tf
@@ -1,6 +1,18 @@
+# see https://www.terraform.io/docs/language/state/remote-state-data.html
+data "terraform_remote_state" "upstream" {
+  backend = "remote"
+
+  config = {
+    organization = "a-demo-organization"
+    workspaces = {
+      name = "dci-azure"
+    }
+  }
+}
+
 # see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group
 data "azurerm_resource_group" "platform" {
-  name = "platform"
+  name = data.terraform_remote_state.upstream.outputs.resource_group_name
 }
 
 # see https://registry.terraform.io/providers/hashicorp/hcs/latest/docs/data-sources/plan_defaults


### PR DESCRIPTION
This PR adds an output for `./terraform/azure` to bubble up the resource group name, so it can be used via `remote_state` data sources for HCS clusters.

